### PR TITLE
validate the modbus Response's numberBytesDeclare if equal  request's numberBytesDeclare,slaveid if equal request's slaveid

### DIFF
--- a/Modbus4J/src/com/serotonin/modbus4j/ModbusMaster.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/ModbusMaster.java
@@ -102,7 +102,10 @@ abstract public class ModbusMaster extends Modbus {
 
     public final ModbusResponse send(ModbusRequest request) throws ModbusTransportException {
         request.validate(this);
-        return sendImpl(request);
+        ModbusResponse modbusResponse = sendImpl(request);
+		modbusResponse.validateResponse(request);
+
+		return modbusResponse;
     }
 
     abstract public ModbusResponse sendImpl(ModbusRequest request) throws ModbusTransportException;

--- a/Modbus4J/src/com/serotonin/modbus4j/msg/ModbusMessage.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/msg/ModbusMessage.java
@@ -26,7 +26,8 @@ import com.serotonin.util.queue.ByteQueue;
 
 abstract public class ModbusMessage {
     protected int slaveId;
-
+    protected int numberBytesDeclare=0;
+    
     public ModbusMessage(int slaveId) throws ModbusTransportException {
         // Validate the node id. Note that a 0 slave id is a broadcast message.
         if (slaveId < 0 /* || slaveId > 247 */)
@@ -38,7 +39,11 @@ abstract public class ModbusMessage {
     public int getSlaveId() {
         return slaveId;
     }
-
+    
+    public int getNumberBytesDeclare() {
+		return numberBytesDeclare;
+	}
+	
     abstract public byte getFunctionCode();
 
     final public void write(ByteQueue queue) {

--- a/Modbus4J/src/com/serotonin/modbus4j/msg/ModbusResponse.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/msg/ModbusResponse.java
@@ -122,6 +122,16 @@ abstract public class ModbusResponse extends ModbusMessage {
         int i2 = b2 & 0xff;
         return i1 > i2;
     }
+    
+    /**
+     * check the Response . slaveid if equal request. slaveid
+     * @param request
+     * @throws ModbusTransportException
+     */
+    public void  validateResponse(ModbusRequest request) throws ModbusTransportException {
+        if(getSlaveId()!=request.slaveId)
+        	throw new ModbusTransportException("Response SlaveId not equal", request.getSlaveId());         	
+    }
 
     public static void main(String[] args) throws Exception {
         ByteQueue queue = new ByteQueue(new byte[] { 3, 2 });

--- a/Modbus4J/src/com/serotonin/modbus4j/msg/ReadNumericRequest.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/msg/ReadNumericRequest.java
@@ -34,6 +34,7 @@ abstract public class ReadNumericRequest extends ModbusRequest {
         super(slaveId);
         this.startOffset = startOffset;
         this.numberOfRegisters = numberOfRegisters;
+        numberBytesDeclare=numberOfRegisters;
     }
 
     @Override

--- a/Modbus4J/src/com/serotonin/modbus4j/msg/ReadResponse.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/msg/ReadResponse.java
@@ -40,6 +40,7 @@ abstract public class ReadResponse extends ModbusResponse {
     @Override
     protected void readResponse(ByteQueue queue) {
         int numberOfBytes = ModbusUtils.popUnsignedByte(queue);
+        numberBytesDeclare=numberOfBytes;
         if (queue.size() < numberOfBytes)
             throw new ArrayIndexOutOfBoundsException();
 

--- a/Modbus4J/src/com/serotonin/modbus4j/msg/ReadResponse.java
+++ b/Modbus4J/src/com/serotonin/modbus4j/msg/ReadResponse.java
@@ -52,6 +52,16 @@ abstract public class ReadResponse extends ModbusResponse {
         ModbusUtils.pushByte(queue, data.length);
         queue.push(data);
     }
+    
+    /**
+     * check the Response's numberBytesDeclare if equal  request's numberBytesDeclare
+     */
+    @Override
+    public void  validateResponse(ModbusRequest request) throws ModbusTransportException {
+    	super.validateResponse(request);
+        if(numberBytesDeclare!=request.getNumberBytesDeclare()*2)
+        	throw new ModbusTransportException("Response NumberByte not expect request", request.getSlaveId());         	
+    }
 
     public byte[] getData() {
         return data;


### PR DESCRIPTION
sometimes, int network weak case, the  modbus message response is not request expect.same likes below
2015/05/19-12:30:27,051 O 15030081006356df
2015/05/19-12:30:33,067 O 15030081006356df
2015/05/19-12:30:39,087 O 150300e5004596da
2015/05/19-12:30:42,117 I 1503c6001500030012000100110002000400010056000200320002000000000002000000030001000400020002000000060001000100020000000000050000000000060030000100190001001300000003000100550000002300020004000100030001001000020001000100070000000200010003000100030001000100000000000600220002001500000015000200050000005100030041000000030000000200010009000100030001000800000004000200030001000300000004000000000127179400460821e8ad
2015/05/19-12:30:42,121 O 19030000005c462b
2015/05/19-12:30:43,438 I 15038a0131002601330004027600090226001702470019017100340115001300560014004200130021002100060024003800080041000000000758163900870599006102810027034700230422000903180018022500060149000101290007009600120192003001650015013500220104001800550000000000451948003512350015055200200737001007760a37
2015/05/19-12:30:43,442 O 1903008100635613
2015/05/19-12:30:45,070 I 1903b8000635670006356700000000000336660000000000033666000000000000000000000000000000000000000000000000500423592359234700000000000000000000000000000000000024021196000000000000000000000000000000000000100010001000100000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000000069007400800000000000001efd

the crc is right,but the response is not the requst want